### PR TITLE
Add key attribute in React repeat example

### DIFF
--- a/_data/frameworks.yml
+++ b/_data/frameworks.yml
@@ -115,7 +115,7 @@
       - **Angular 2:** See [Angular Cheat Sheet](https://angular.io/docs/ts/latest/guide/cheatsheet.html).
   - label: Repeat
     frameworks:
-      react: items.map(item => <div></div>)
+      react: items.map(item => <div key={item.id}></div>)
       angular2: <div *ngFor="let item of items"></div>
       angular1: <div ng-repeat="item in items"></div>
       polymer: <template is="dom-repeat" items="{{items}}"></template>


### PR DESCRIPTION
While other frameworks can take care about repeating items, React requires special key attribute. There is a [section in React documentation](https://facebook.github.io/react/docs/multiple-components.html#dynamic-children) about this.

Unless you do it, you will get a warning from React in developer mode.
