### PR TITLE
Fixed one-way data binding in Angular 1

### DIFF
--- a/_data/frameworks.yml
+++ b/_data/frameworks.yml
@@ -178,7 +178,7 @@
     frameworks:
       react: <Child foo={bar} />
       angular2: <Child [foo]="bar" />
-      angular1: <Child foo='scope.bar' />
+      angular1: <Child foo="{{ bar }}" />
       polymer: '<Child foo="{{ bar }}" />'
       vue: <Child :foo='bar' />
       ember: "{{Child foo=(readonly bar) }}"


### PR DESCRIPTION
It could either be

``` js
<div foo="bar"/>
```

or

``` js
<div foo="{{ bar }}"/>
```

depending on how the directive is configured. But you never direct access the `scope` variable.
